### PR TITLE
fix WebKit transparent gradient

### DIFF
--- a/pkg/packagekit/updates.less
+++ b/pkg/packagekit/updates.less
@@ -24,7 +24,7 @@ tr.listing-ct-item {
             overflow: visible;
 
             .truncating {
-                background: linear-gradient(to left, transparent, #def3ff 3em);
+                background: linear-gradient(to left, rgba(222, 243, 255, 0), rgb(222, 243, 255) 3em);
                 position: relative;
                 padding: 0.5em 4em 0.5em 0;
             }
@@ -44,7 +44,7 @@ tr.listing-ct-item {
 tbody.open {
     td.version:hover .truncating {
         /* Adapt background color for version expansion when row is expanded */
-        background: linear-gradient(to left, transparent, #ededed 3em);
+        background: linear-gradient(to left, rgba(237, 237, 237, 0), rgb(237, 237, 237) 3em);
     }
 }
 


### PR DESCRIPTION
WebKit does not go from transparent to color well. Some browsers don't support hex RGBA. Therefore, using rgba() to support all browsers with a transparent gradient. This includes Firefox, Chrome, WebKit, Edge, & even IE11.